### PR TITLE
Fix Squareys/vim-cmake#2 (partial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script: |
 
 script:
     - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc' -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc' -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script:
   - cmake --version
 
 script:
-    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader' > /dev/null
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader' > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script:
   - cmake --version
 
 script:
-    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader' > /dev/null
-    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader' > /dev/null
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ before_script:
 
 script:
     - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader'
-    - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
 script:
-    # - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader' </dev/zero
-    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,7 @@ addons:
 before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
-script: |
-  vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+script:
+    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script: |
 
 script:
     # - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script: |
 
 script:
     # - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader' </dev/zero
     # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
 
 script:
     - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc' -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc' -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader'
+    - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
 script:
-    - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-    - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+    # - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+    # - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
     - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ addons:
     - g++-4.7
     - cmake
 
-before_script: |
-  git clone https://github.com/junegunn/vader.vim.git
+before_script:
+  - git clone https://github.com/junegunn/vader.vim.git
+  - cmake --version
 
 script:
     - vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ git clone https://github.com/junegunn/vader.vim
 
 # Run tests
 vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
-vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader'
-vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader'
+vim -Nu 'test/.vimrc' -c 'Vader! test/cmake_quickfix.vader'
 ```
 
 For test file syntax highlighting, add vader.vim as a plugin to your .vimrc.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ git clone https://github.com/junegunn/vader.vim
 
 # Run tests
 vim -Nu 'test/.vimrc' -c 'Vader! test/cmake.vader'
+vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader'
+vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader'
 ```
 
 For test file syntax highlighting, add vader.vim as a plugin to your .vimrc.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This project was originally forked from [vhdirk/vim-cmake](https://github.com/vh
 
 ### Commands
 
- * `:CMake` searches for the closest directory named build in an upwards search,
-and whenever one is found, it runs the cmake command there, assuming the CMakeLists.txt
-file is just one directory above. Any arguments given to :CMake will be directly passed
-on to the cmake command. It also sets the working directory of the make command, so
-you can just use quickfix as with a normal Makefile project.
+ * `:CMake` searches for the closest directory named as specified by `g:cmake_build_dir`.
+The directory is searched for upwards from the current directory. If that does not lead to a result it tries again from the directory of the current file.
+When a dir is found, it runs the cmake command there, assuming the CMakeLists.txt
+file in `..` relative to the build dir.
+Any arguments given to :CMake will be directly passed on to the cmake command.
+Finally, this command sets `makeprg` to (effectively) `cmake --build <build-dir> --target ` for you to simply compile the project using `:make <target>`.
 
  * `:CMakeClean` deletes all files in the build directory. You can think of this as a CMake version of make clean.
 
@@ -91,7 +92,8 @@ For test file syntax highlighting, add vader.vim as a plugin to your .vimrc.
     * @jmirabel for fixing concatenation of cmake arguments.
     * @T4ng10r for the project generator option.
     * @Squareys for a small overhaul of the project, the initial test and travis setup.
-    * @darth for fixing passing arguments to CMake command
+    * @darth for fixing passing arguments to CMake command.
+    * @richteraj for the initial support for opening configure errors during `:CMake` in the quickfix list.
 
 ## License
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,5 @@ install:
 
 build_script:
   - vim -Nu test/.vimrc -c 'Vader! test/cmake.vader' --not-a-term
-  - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
-  - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'
+  - vim -Nu test/.vimrc -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake.vader' --not-a-term
+  - vim -Nu test/.vimrc -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake_quickfix.vader' --not-a-term

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,3 +8,5 @@ install:
 
 build_script:
   - vim -Nu test/.vimrc -c 'Vader! test/cmake.vader' --not-a-term
+  - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake.vader'
+  - vim -Nu 'test/.vimrc_with_quickfix' -c 'Vader! test/cmake_quickfix.vader'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,5 @@ install:
 
 build_script:
   - vim -Nu test/.vimrc -c 'Vader! test/cmake.vader' --not-a-term
-  - vim -Nu test/.vimrc -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake.vader' --not-a-term
-  - vim -Nu test/.vimrc -c 'let g:cmake_config_in_quickfix = 1 | Vader! test/cmake_quickfix.vader' --not-a-term
+  - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader' --not-a-term
+  - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader' --not-a-term

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,4 @@ install:
 
 build_script:
   - vim -Nu test/.vimrc -c 'Vader! test/cmake.vader' --not-a-term
-  - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake_quickfix.vader' --not-a-term
-  - vim -Nu 'test/.vimrc' --cmd 'let g:cmake_config_in_quickfix = 1' -c 'Vader! test/cmake.vader' --not-a-term
+  - vim -Nu test/.vimrc -c 'Vader! test/cmake_quickfix.vader' --not-a-term

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -31,6 +31,7 @@ let s:cmake_errors = []
 let s:cmake_errors += ['CMake %trror at %f:%l (%m):']
 let s:cmake_errors += ['CMake %trror at %f:%l:']
 let s:cmake_errors += ['CMake %trror in %f:']
+let s:cmake_errors += ['CMake %trror: %m']
 let &errorformat .= ',' . join(s:cmake_errors, ',')
 
 function! s:find_build_dir()

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -45,7 +45,7 @@ function! s:create_compile_commands_symlink()
     if has("win32")
       silent echo system("mklink ../compile_commands.json " . b:build_dir . "/compile_commands.json")
     else
-      silent echo system("ln -s " . b:build_dir ."/compile_commands.json ../compile_commands.json")
+      silent echo system("ln -s " . s:fnameescape(b:build_dir) ."/compile_commands.json ../compile_commands.json")
     endif
 endfunction
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -152,7 +152,6 @@ function! s:cmake_configure(...)
   let s:cmd .= l:argumentstr . ' ' . join(a:000)
   echo s:cmd
   call s:run_as_makeprg(s:cmd)
-  "silent echo s:res
 
   exec 'cd -'
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -26,6 +26,13 @@ if !executable("cmake")
   finish
 endif
 
+" CMake error rudimentary parsing
+let s:cmake_errors = []
+let s:cmake_errors += ['CMake %trror at %f:%l (%m):']
+let s:cmake_errors += ['CMake %trror at %f:%l:']
+let s:cmake_errors += ['CMake %trror in %f:']
+let &errorformat .= ',' . join(s:cmake_errors, ',')
+
 function! s:find_build_dir()
   " Do not overwrite already found build_dir, may be set explicitly
   " by user.

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -133,10 +133,12 @@ function! s:cmake_configure(...)
     let &makeprg = l:mp
     exec 'cd -'
   else
+    exec 'cd' s:fnameescape(b:build_dir)
     let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)
     echo s:cmd
     silent let s:res = system(s:cmd)
     silent echo s:res
+    exec 'cd -'
   endif
 
   exec 'cd' s:fnameescape(b:build_dir)

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -165,7 +165,7 @@ function! s:cmake_configure(...)
 
   " Create symbolic link to compilation database for use with YouCompleteMe
   if g:cmake_ycm_symlinks && filereadable("compile_commands.json")
-    s:create_compile_commands_symlink()
+    call s:create_compile_commands_symlink()
     echom "Created symlink to compilation database"
   endif
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -132,6 +132,12 @@ function! s:cmake_configure(...)
 
     let &makeprg = l:mp
     exec 'cd -'
+
+    " If there were make errors another buffer might get opened, therefore
+    " setting "b:build_dir" again
+    if !s:find_build_dir()
+      return
+    endif
   else
     exec 'cd' s:fnameescape(b:build_dir)
     let s:cmd = 'cmake .. '. l:argumentstr . " " . join(a:000)

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -191,7 +191,10 @@ function! s:cmake(...)
     return
   endif
 
-  let &makeprg = 'cmake --build ' . s:fnameescape(b:build_dir) . ' --target'
+  " the result of fnameescape may contain a trailing '\' character, which will
+  " escpae the '"' after. To avoid this, we substitute \\ with / to normalize
+  " the path.
+  let &makeprg = 'cmake --build "' . substitute(s:fnameescape(b:build_dir), "\\", "/", "g") . '" --target'
   call call('s:cmake_configure', a:000)
 endfunction
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -179,10 +179,10 @@ function! s:cmake(...)
     return
   endif
 
-  " the result of fnameescape may contain a trailing '\' character, which will
-  " escpae the '"' after. To avoid this, we substitute \\ with / to normalize
-  " the path.
-  let &makeprg = 'cmake --build "' . substitute(s:fnameescape(b:build_dir), "\\", "/", "g") . '" --target'
+  " CMake outputs errors relative to project directory. We therefore tell
+  let &makeprg = '((echo CMake enter dir: ' . s:fnameescape(b:proj_dir) . ')'
+  let &makeprg .= '&& cmake --build "' . s:fnameescape(b:build_dir) . '" --target $*)'
+  "let &makeprg .= '&& (echo CMake leave dir: ' . s:fnameescape(b:proj_dir) . ')'
   call call('s:cmake_configure', a:000)
 endfunction
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -52,6 +52,7 @@ function! s:find_build_dir()
     " expand() would expand "" to working directory, but we need
     " this as an indicator that build was not found
     let b:build_dir = fnamemodify(b:build_dir, ':p')
+    let b:proj_dir = fnamemodify(b:build_dir, ':p:h:h')
     echom "Found cmake build directory: " . s:fnameescape(b:build_dir)
     return 1
   else
@@ -141,6 +142,8 @@ command! -nargs=? CMake call s:cmake(<f-args>)
 command! CMakeClean call s:cmakeclean()
 command! CMakeFindBuildDir call s:cmake_find_build_dir()
 
+command! -nargs=? CMakeCDMake call s:cd_make(<f-args>)
+
 function! s:cmake_find_build_dir()
   if exists("b:build_dir")
       unlet b:build_dir
@@ -166,3 +169,12 @@ function! s:cmakeclean()
   echom "Build directory has been cleaned."
 endfunction
 
+function! s:cd_make(...)
+  if !s:find_build_dir()
+    return
+  endif
+
+  exec 'cd' s:fnameescape(b:proj_dir)
+  exec 'make '. join(a:000)
+  exec 'cd -'
+endfunction

--- a/test/.vimrc_with_quickfix
+++ b/test/.vimrc_with_quickfix
@@ -1,9 +1,0 @@
-filetype off
-
-set rtp+=vader.vim
-set rtp+=.
-filetype plugin indent on
-syntax enable
-
-let g:cmake_config_in_quickfix = 1
-

--- a/test/.vimrc_with_quickfix
+++ b/test/.vimrc_with_quickfix
@@ -1,0 +1,9 @@
+filetype off
+
+set rtp+=vader.vim
+set rtp+=.
+filetype plugin indent on
+syntax enable
+
+let g:cmake_config_in_quickfix = 1
+

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -87,7 +87,7 @@ Execute (Configure by passing addition arguments to :CMake):
   silent make
 
   enew
-  if has("win32")
+  if has("win32") || has("win32unix")
     Assert filereadable("Debug/hello.exe"), "Binary of cmake build output not found."
     silent read !Debug/hello.exe
   else

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -9,8 +9,13 @@ Before:
   endif
 
   Assert !isdirectory("test project/tmp-build"), "TEST ERROR: build directory was not properly deleted"
-  echo system("mkdir 'test project/tmp-build'")
-  Assert isdirectory("test project/tmp-build"), "TEST ERROR: build directory was not created"
+  if has("win32")
+    echo system('mkdir "test project\\tmp-build"')
+  else
+    echo system("mkdir 'test project/tmp-build'")
+  endif
+  Assert isdirectory("test project/tmp-build"),
+    \ "TEST ERROR: build directory was not created"
 
   " Under travis CI the entire project is in a build/ directory
   " which will make the search from cwd always return a result.
@@ -19,8 +24,13 @@ Before:
   let g:cmake_build_dir = "tmp-build"
 After:
   exec "cd" fnameescape(test_dir)
-  echo system("rm -rf 'test project/tmp-build'")
-  echo system("rm -f 'test project/compile_commands.json'")
+  if has("win32")
+    echo system('rmdir /S/Q "test project\tmp-build"')
+    echo system('del /Q "test project\compile_commands.json"')
+  else
+    echo system("rm -rf 'test project/tmp-build'")
+    echo system("rm -f 'test project/compile_commands.json'")
+  endif
 
 Execute (Find build directory from working dir):
   cd test\ project
@@ -30,9 +40,12 @@ Execute (Find build directory from working dir):
   Assert !filereadable("tmp-build/compile_commands.json"), "Compile commands should not be exported by default"
 
 Execute (Find build directory from currently open file):
+  " No cd to proper dir, ensure fallback to from file search
   e test\ project/CMakeLists.txt
-  CMake
-  Assert filereadable("test project/tmp-build/CMakeCache.txt"), "CMakeCache.txt should be generated"
+  CMakeFindBuildDir
+  Assert g:cmake_build_dir == "tmp-build", "CMakeFindBuildDir changed the g:cmake_build_dir variable"
+  Assert exists("b:build_dir"), "Should be able to find dir from open file"
+  "Assert filereadable("test project/tmp-build/CMakeCache.txt"), "CMakeCache.txt should be generated"
 
 Execute (Create symlink to compilation database):
   let g:cmake_export_compile_commands = 1
@@ -71,7 +84,9 @@ Execute (Configure by passing addition arguments to :CMake):
   silent make
 
   enew
-  if has("win32") || has("win32unix")
+  if has("win32")
+    read !"Debug\hello.exe"
+  elseif has("win32unix")
     read !Debug/hello.exe
   else
     read !./hello

--- a/test/cmake.vader
+++ b/test/cmake.vader
@@ -48,13 +48,14 @@ Execute (Find build directory from currently open file):
   "Assert filereadable("test project/tmp-build/CMakeCache.txt"), "CMakeCache.txt should be generated"
 
 Execute (Create symlink to compilation database):
-  let g:cmake_export_compile_commands = 1
-  let g:cmake_ycm_symlinks = 1
-  cd test\ project
-  CMake
-
   " Exporting compile commands does not work with Visual Studio generator
   if !has("win32") && !has("win32unix")
+    let g:cmake_export_compile_commands = 1
+    let g:cmake_ycm_symlinks = 1
+    cd test\ project
+
+    CMake
+
     Assert filereadable("tmp-build/compile_commands.json"), "Compile commands should be exported"
     Assert filereadable(resolve("compile_commands.json")), "A symlink should be generated"
   endif
@@ -63,14 +64,16 @@ Execute (Open already configured cmake project):
   cd test\ project/tmp-build
   silent !cmake .. -DWITH_BYE=ON
   e ../CMakeLists.txt
-  CMake
+  silent CMake
   silent make
 
   enew
   if has("win32") || has("win32unix")
-    read !Debug/hello.exe
+    Assert filereadable("Debug/hello.exe"), "Binary of cmake build output not found."
+    silent read !Debug/hello.exe
   else
-    read !./hello
+    Assert filereadable("hello"), "Binary of cmake build output not found."
+    silent read !./hello
   endif
 Expect:
 
@@ -85,11 +88,11 @@ Execute (Configure by passing addition arguments to :CMake):
 
   enew
   if has("win32")
-    read !"Debug\hello.exe"
-  elseif has("win32unix")
-    read !Debug/hello.exe
+    Assert filereadable("Debug/hello.exe"), "Binary of cmake build output not found."
+    silent read !Debug/hello.exe
   else
-    read !./hello
+    Assert filereadable("hello"), "Binary of cmake build output not found."
+    silent read !./hello
   endif
 Expect:
 

--- a/test/cmake_quickfix.vader
+++ b/test/cmake_quickfix.vader
@@ -1,0 +1,60 @@
+Before:
+  " This variable has to bet set before loading plugins, i.e. inside a vimrc
+  " file
+  " let g:cmake_config_in_quickfix = 1
+
+  " Ensure we are in the test directory
+  if isdirectory("test")
+    cd test
+  endif
+
+  if !exists("test_dir")
+    let test_dir = fnamemodify(getcwd(), ':p')
+  endif
+
+  let test_proj_dir = "test project_bad_cmake"
+  let g:cmake_build_dir = "tmp-build"
+  let test_build_dir = test_proj_dir."/".g:cmake_build_dir
+
+  Assert !isdirectory(test_build_dir),
+    \ "TEST ERROR: build directory was not properly deleted"
+  echo system("mkdir '".test_build_dir."'")
+  Assert isdirectory(test_build_dir),
+    \ "TEST ERROR: build directory was not created"
+  Assert !filereadable(test_proj_dir . "/.CMakeLists.txt.swp"),
+    \ "TEST ERROR: swap file of CMakeLists.txt exists"
+
+After:
+  exec "cd" fnameescape(test_dir)
+  echo system("rm -rf '".test_build_dir."'")
+
+
+Execute (:CMake jumps to error in CMakeLists.txt file):
+  exec "cd" fnameescape(test_proj_dir)
+  CMake
+  cc!
+Then:
+  AssertEqual expand('%:p'), fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt",
+    \ ":cc did not open ".fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt but ".expand("%:p")
+Expect:
+  cmake_minimum_required(VERSION 2.8.12)
+  
+  projec(Syntax_Error)
+
+
+Execute (:CMake jumps to error in CMakeLists.txt file from arbitrary directory):
+  exec "cd" fnameescape(test_proj_dir)
+  CMakeFindBuildDir
+  exec "cd" fnameescape(test_dir)
+  cd ..
+  CMake
+  cc!
+Then:
+  AssertEqual expand('%:p'), fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt",
+    \ ":cc did not open ".fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt but ".expand("%:p")
+  Assert isdirectory("test"), ":CMake did not properly reset working directory"
+Expect:
+  cmake_minimum_required(VERSION 2.8.12)
+  
+  projec(Syntax_Error)
+

--- a/test/cmake_quickfix.vader
+++ b/test/cmake_quickfix.vader
@@ -38,7 +38,7 @@ Then:
     \ ":cc did not open ".fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt but ".expand("%:p")
 Expect:
   cmake_minimum_required(VERSION 2.8.12)
-  
+
   projec(Syntax_Error)
 
 
@@ -55,6 +55,6 @@ Then:
   Assert isdirectory("test"), ":CMake did not properly reset working directory"
 Expect:
   cmake_minimum_required(VERSION 2.8.12)
-  
+
   projec(Syntax_Error)
 

--- a/test/cmake_quickfix.vader
+++ b/test/cmake_quickfix.vader
@@ -1,8 +1,4 @@
 Before:
-  " This variable has to bet set before loading plugins, i.e. inside a vimrc
-  " file
-  " let g:cmake_config_in_quickfix = 1
-
   " Ensure we are in the test directory
   if isdirectory("test")
     cd test
@@ -12,30 +8,38 @@ Before:
     let test_dir = fnamemodify(getcwd(), ':p')
   endif
 
-  let test_proj_dir = "test project_bad_cmake"
   let g:cmake_build_dir = "tmp-build"
-  let test_build_dir = test_proj_dir."/".g:cmake_build_dir
 
-  Assert !isdirectory(test_build_dir),
-    \ "TEST ERROR: build directory '".test_build_dir."' was not properly deleted"
-  echo system("mkdir '".test_build_dir."'")
-  Assert isdirectory(test_build_dir),
+  Assert !isdirectory("test project_bad_cmake/tmp-build"),
+    \ "TEST ERROR: build directory 'test project_bad_cmake/tmp-build' was not properly deleted"
+  if has("win32")
+    echo system('mkdir "test project_bad_cmake\\tmp-build"')
+  else
+    echo system("mkdir 'test project_bad_cmake/tmp-build'")
+  endif
+  Assert isdirectory("test project_bad_cmake/tmp-build"),
     \ "TEST ERROR: build directory was not created"
-  Assert !filereadable(test_proj_dir . "/.CMakeLists.txt.swp"),
+  Assert !filereadable("test project_bad_cmake/.CMakeLists.txt.swp"),
     \ "TEST ERROR: swap file of CMakeLists.txt exists"
 
 After:
   exec "cd" fnameescape(test_dir)
-  echo system("rm -rf '".test_build_dir."'")
+  if has("win32")
+    echo system('rmdir /S/Q "test project_bad_cmake\tmp-build"')
+    echo system('del /Q "test project_bad_cmake\compile_commands.json"')
+  else
+    echo system("rm -rf 'test project_bad_cmake/tmp-build'")
+    echo system("rm -f 'test project_bad_cmake/compile_commands.json'")
+  endif
 
 
 Execute (:CMake jumps to error in CMakeLists.txt file):
-  exec "cd" fnameescape(test_proj_dir)
+  cd test\ project_bad_cmake
   CMake
   cc!
 Then:
-  AssertEqual expand('%:p'), fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt",
-    \ ":cc did not open ".fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt but ".expand("%:p")
+  AssertEqual expand('%:p'), fnamemodify(test_dir."test\ project_bad_cmake", ":p")."CMakeLists.txt",
+    \ ":cc did not open ".fnamemodify(test_dir."test\ project_bad_cmake", ":p")."CMakeLists.txt but ".expand("%:p")
 Expect:
   cmake_minimum_required(VERSION 2.8.12)
 
@@ -43,15 +47,15 @@ Expect:
 
 
 Execute (:CMake jumps to error in CMakeLists.txt file from arbitrary directory):
-  exec "cd" fnameescape(test_proj_dir)
+  cd test\ project_bad_cmake
   CMakeFindBuildDir
   exec "cd" fnameescape(test_dir)
   cd ..
   CMake
   cc!
 Then:
-  AssertEqual expand('%:p'), fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt",
-    \ ":cc did not open ".fnamemodify(test_dir.test_proj_dir, ":p")."CMakeLists.txt but ".expand("%:p")
+  AssertEqual expand('%:p'), fnamemodify(test_dir."test\ project_bad_cmake", ":p")."CMakeLists.txt",
+    \ ":cc did not open ".fnamemodify(test_dir."test\ project_bad_cmake", ":p")."CMakeLists.txt but ".expand("%:p")
   Assert isdirectory("test"), ":CMake did not properly reset working directory"
 Expect:
   cmake_minimum_required(VERSION 2.8.12)

--- a/test/cmake_quickfix.vader
+++ b/test/cmake_quickfix.vader
@@ -17,7 +17,7 @@ Before:
   let test_build_dir = test_proj_dir."/".g:cmake_build_dir
 
   Assert !isdirectory(test_build_dir),
-    \ "TEST ERROR: build directory was not properly deleted"
+    \ "TEST ERROR: build directory '".test_build_dir."' was not properly deleted"
   echo system("mkdir '".test_build_dir."'")
   Assert isdirectory(test_build_dir),
     \ "TEST ERROR: build directory was not created"

--- a/test/test project_bad_cmake/CMakeLists.txt
+++ b/test/test project_bad_cmake/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+projec(Syntax_Error)


### PR DESCRIPTION
Trying to build from an incomplete configuration, i.e. `:Cmake` with
errors and then `:make`, set the quickfix list to an error in the
generated Makefile under the build directory. This resulted in an empty
file while trying to follow the error.
Now the `CMakeList.txt` file, which contains the error, will be opened.

The link for `Makefile|xx| recipe for target '...' failed` is still not
working.