### PR TITLE
Added g:cmake_build_dir_override

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Finally, this command sets `makeprg` to (effectively) `cmake --build <build-dir>
 
  * `b:build_dir` is the path to the cmake build directory for the current buffer. This variable is set with the first :CMake or :CMakeFindBuildDir call. Once found, it will not be searched for again unless you call :CMakeFindBuildDir. If automatic finding is not sufficient you can set this variable manually to the build dir of your choice.
 
+ * `g:cmake_build_dir_override` can be used to override the complete build directory path.  If the directory does not exist and `mkdir()` is supported it will be automatically created.
 
 ## Installation
 

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -68,6 +68,15 @@ function! s:find_build_dir()
     return 1
   endif
 
+  if exists("g:cmake_build_dir_override")
+    if exists("*mkdir")
+      call mkdir(g:cmake_build_dir_override, "p", 0700)
+    endif
+    let b:build_dir = g:cmake_build_dir_override
+    let b:proj_dir = fnamemodify(b:build_dir, ':h')
+    return 1
+  endif
+
   let g:cmake_build_dir = get(g:, 'cmake_build_dir', 'build')
   let b:build_dir = s:search_upward_for(g:cmake_build_dir, "")
 
@@ -227,3 +236,4 @@ function! s:cd_make(...)
   exec 'make '. join(a:000)
   exec 'cd -'
 endfunction
+" vim: set tabstop=2 softtabstop=0 expandtab shiftwidth=2:


### PR DESCRIPTION
Added `g:cmake_build_dir_override` to automatically create a build directory.  I really suck at naming things so feel free to suggest a different name.  I'm using this as follows:

```
let s:git_root = systemlist("git rev-parse --show-toplevel")
if filereadable("CMakeLists.txt") && !empty(s:git_root)
    let g:cmake_build_dir_override = s:git_root[0] . "/build"
    ...
endif
```